### PR TITLE
action submit for search input

### DIFF
--- a/src/app/search-bar/search-bar.component.html
+++ b/src/app/search-bar/search-bar.component.html
@@ -11,6 +11,7 @@
   [resultFormatter]="resultFormatter"
   [resultTemplate]="resultTpl"
   (selectItem)="onSelect($event)"
+  (keydown.enter)="onSubmit()"
   [focusFirst]="false"
   #typeaheadInstance="ngbTypeahead"
 />

--- a/src/app/search-bar/search-bar.component.spec.ts
+++ b/src/app/search-bar/search-bar.component.spec.ts
@@ -191,6 +191,74 @@ describe('SearchBarComponent', () => {
     });
   });
 
+  describe('onSubmit', () => {
+    let routerSpy: ReturnType<typeof vi.spyOn>;
+    let dismissSpy: ReturnType<typeof vi.spyOn>;
+    let activeDescendantValue: string | null;
+
+    beforeEach(() => {
+      routerSpy = vi.spyOn(component['router'], 'navigate');
+      dismissSpy = vi.spyOn(component.typeaheadInstance, 'dismissPopup');
+      activeDescendantValue = null;
+      Object.defineProperty(component.typeaheadInstance, 'activeDescendant', {
+        get: () => activeDescendantValue,
+        set: (v: string | null) => {
+          activeDescendantValue = v;
+        },
+        configurable: true,
+      });
+    });
+
+    it('should navigate to /search/:query when query >= 2 chars and no active typeahead item', () => {
+      component.query.set('rock');
+
+      ngZone.run(() => {
+        component.onSubmit();
+      });
+
+      expect(component.query()).toBe('');
+      expect(dismissSpy).toHaveBeenCalled();
+      expect(routerSpy).toHaveBeenCalledWith(['/search', 'rock']);
+    });
+
+    it('should not navigate when query is less than 2 chars', () => {
+      component.query.set('a');
+
+      ngZone.run(() => {
+        component.onSubmit();
+      });
+
+      expect(routerSpy).not.toHaveBeenCalled();
+      expect(dismissSpy).not.toHaveBeenCalled();
+      expect(component.query()).toBe('a');
+    });
+
+    it('should not navigate when a typeahead item is active', () => {
+      component.query.set('rock');
+      activeDescendantValue = 'ngb-typeahead-0-0';
+
+      ngZone.run(() => {
+        component.onSubmit();
+      });
+
+      expect(routerSpy).not.toHaveBeenCalled();
+      expect(dismissSpy).not.toHaveBeenCalled();
+      expect(component.query()).toBe('rock');
+    });
+
+    it('should trim whitespace from query before navigating', () => {
+      component.query.set('  rock  ');
+
+      ngZone.run(() => {
+        component.onSubmit();
+      });
+
+      expect(component.query()).toBe('');
+      expect(dismissSpy).toHaveBeenCalled();
+      expect(routerSpy).toHaveBeenCalledWith(['/search', 'rock']);
+    });
+  });
+
   describe('searchTypeahead', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -50,6 +50,7 @@ export class SearchBarComponent {
   ) =>
     text$.pipe(
       debounceTime(300),
+      map(term => term.trim()),
       distinctUntilChanged(),
       filter(term => term.length >= 2),
       switchMap(term =>
@@ -124,6 +125,22 @@ export class SearchBarComponent {
 
     this.query.set('');
     this.router.navigate([item.navigateUrl]);
+  }
+
+  /** Handle Enter key — navigate to full search results if no typeahead item is active */
+  onSubmit(): void {
+    if (this.typeaheadInstance.activeDescendant) {
+      return;
+    }
+
+    const trimmed = this.query().trim();
+    if (trimmed.length < 2) {
+      return;
+    }
+
+    this.typeaheadInstance.dismissPopup();
+    this.query.set('');
+    this.router.navigate(['/search', trimmed]);
   }
 
   getQuerystr(): string {


### PR DESCRIPTION
This pull request enhances the `SearchBarComponent` by adding support for submitting a search query with the Enter key, provided no typeahead suggestion is actively selected. It also introduces comprehensive unit tests for this new behavior to ensure correct navigation logic and proper handling of edge cases.

**Feature addition:**

* Added an `(keydown.enter)="onSubmit()"` event binding to the search bar template, allowing users to trigger a search by pressing Enter when no typeahead item is active.
* Implemented the `onSubmit` method in `SearchBarComponent` to handle Enter key submissions, ensuring:
  - Navigation only occurs if the query is at least 2 characters and no suggestion is selected.
  - Whitespace is trimmed from the query before navigation.
  - The typeahead popup is dismissed and the query input is cleared after submission.

**Testing improvements:**

* Added a dedicated test suite for `onSubmit` in `search-bar.component.spec.ts` to verify:
  - Navigation is triggered appropriately for valid queries.
  - No navigation occurs for short queries or when a suggestion is selected.
  - Query trimming and popup dismissal are handled correctly.