### PR TITLE
fix delivery pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.19.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Install dependencies
@@ -103,14 +103,12 @@ jobs:
             echo "SENTRY_AUTH_TOKEN not set, skipping source map upload"
             exit 0
           fi
+          npx @sentry/cli@2.42.2 sourcemaps inject dist/
           npx @sentry/cli@2.42.2 sourcemaps upload \
             --org zeffyr \
             --project zeffyrmusic \
             --release "zeffyrmusic@${{ github.sha }}" \
-            --url-prefix "~/" \
-            --strip-common-prefix \
-            --validate \
-            dist/browser/
+            dist/
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "web-codegen-scorer": "^0.0.70"
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.0.0"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "*",


### PR DESCRIPTION
This pull request updates the project's Node.js version requirements and makes adjustments to the Sentry sourcemap upload process in the CI workflow. The main goals are to ensure compatibility with Node.js 22 and to improve the way sourcemaps are handled during deployment.

**Node.js version updates:**

* Updated the Node.js version used in the GitHub Actions CI workflow from `20.19.x` to `22.x` (`.github/workflows/ci.yml`).
* Increased the minimum Node.js version required in the `package.json` engines field from `>=20.19.0` to `>=22.0.0`.

**Sentry sourcemap upload improvements:**

* Added a step to inject sourcemaps into the `dist/` directory before uploading to Sentry, and simplified the upload command by removing unused options and changing the upload path from `dist/browser/` to `dist/` (`.github/workflows/ci.yml`).