### PR TITLE
handle edge cases sentry

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,7 @@
 - **English only** for comments — no French
 - **Vitest** for tests — not Jest/Jasmine
 - **Modern control flow**: `@if`, `@for`, `@switch` — not `*ngIf`, `*ngFor`
+- **Chunk error recovery**: `withNavigationErrorHandler()` in `app.config.ts` — auto-reloads once on stale chunk errors (post-deploy)
 
 ## Component Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,8 @@ Every routed component must set title, meta description, and canonical URL via `
 
 All routes lazy-loaded except `HomeComponent`. Protected by `AuthGuard`: `like`, `settings`, `my-playlists`, `my-selection`.
 
+**Chunk loading error recovery** (`app.config.ts`): `withNavigationErrorHandler()` catches stale chunk errors after deployments (e.g. `TypeError: error loading dynamically imported module`). On first failure, it sets a `chunk-retry` item in `sessionStorage` and reloads the page. On second failure, it removes that item without reloading to prevent infinite loops. The item is also cleared after a successful bootstrap via `clearChunkRetryFlag()` in `main.ts`, so each deployment can benefit from a fresh retry.
+
 ## Design System
 
 CSS custom properties defined in `_custom.scss` `:root`:

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -5,8 +5,14 @@ import { provideShareButtonsOptions, withConfig } from 'ngx-sharebuttons';
 import { shareIcons } from 'ngx-sharebuttons/icons';
 import { httpConfigInterceptor } from './interceptor/httpConfigInterceptor';
 import { errorInterceptor } from './interceptor/errorInterceptor';
-import { provideRouter, withPreloading, withViewTransitions } from '@angular/router';
+import {
+  provideRouter,
+  withNavigationErrorHandler,
+  withPreloading,
+  withViewTransitions,
+} from '@angular/router';
 import { CustomPreloadStrategy } from './routing/custom-preload.strategy';
+import { handleChunkLoadError } from './routing/chunk-error-handler';
 import { routes } from './app.routes';
 import { provideTransloco } from '@jsverse/transloco';
 import { provideTranslocoMessageformat } from '@jsverse/transloco-messageformat';
@@ -21,6 +27,7 @@ export const appConfig: ApplicationConfig = {
     provideRouter(
       routes,
       withPreloading(CustomPreloadStrategy),
+      withNavigationErrorHandler(handleChunkLoadError),
       withViewTransitions({
         skipInitialTransition: true,
         onViewTransitionCreated: () => {

--- a/src/app/interceptor/errorInterceptor.spec.ts
+++ b/src/app/interceptor/errorInterceptor.spec.ts
@@ -140,6 +140,14 @@ describe('errorInterceptor', () => {
     expect(loggingServiceMock.captureError).not.toHaveBeenCalled();
   });
 
+  it('should NOT report network errors (status 0) to LoggingService', () => {
+    http.get('/api/test').subscribe({ error: () => undefined });
+
+    httpTesting.expectOne('/api/test').error(new ProgressEvent('error'));
+
+    expect(loggingServiceMock.captureError).not.toHaveBeenCalled();
+  });
+
   it('should skip ping requests', () => {
     const showErrorSpy = vi.spyOn(uiStore, 'showError');
     const logoutSpy = vi.spyOn(authStore, 'logout');

--- a/src/app/interceptor/errorInterceptor.ts
+++ b/src/app/interceptor/errorInterceptor.ts
@@ -10,7 +10,8 @@ import { sanitizeUrl } from '../utils';
 
 /**
  * Global HTTP error interceptor.
- * Handles 401, 403, 500+ and timeout errors centrally.
+ * Handles 0 (network/aborted failures), 401, 403, 500+ errors centrally.
+ * Skips Sentry reporting for non-actionable statuses (0, 401).
  * Individual services can still add their own catchError for specific handling.
  */
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
@@ -27,8 +28,10 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
         return throwError(() => error);
       }
 
-      // Report to Sentry — skip 401 (session expiry is a normal flow)
-      if (error.status !== 401) {
+      // Report to Sentry — skip non-actionable statuses:
+      // - 401: session expiry is a normal user flow, not an error
+      // - 0: aborted request (navigation change, tab close, or network offline) — not a server issue
+      if (error.status !== 401 && error.status !== 0) {
         const path = sanitizeUrl(req.url);
         loggingService.captureError(new Error(`HTTP ${error.status} on ${req.method} ${path}`), {
           'http.url': path,
@@ -51,7 +54,8 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
           break;
 
         case 0:
-          // Network error or timeout
+          // Status 0: request aborted — network offline, navigation change, or timeout.
+          // Show user feedback but don't report to Sentry (filtered above).
           uiStore.showError(translocoService.translate('perte_connexion'));
           break;
 

--- a/src/app/my-playlists/my-playlists.component.ts
+++ b/src/app/my-playlists/my-playlists.component.ts
@@ -178,7 +178,7 @@ export class MyPlaylistsComponent implements OnInit {
     this.playlistService.getPlaylist('', idPlaylist).subscribe({
       next: playlist => {
         const modalRef = this.modalService.open(ExportPlaylistModalComponent, { size: 'lg' });
-        modalRef.componentInstance.tracks.set(playlist.tab_video);
+        modalRef.componentInstance.tracks.set(playlist.tab_video ?? []);
         modalRef.componentInstance.playlistTitle.set(titre);
       },
       error: () => {

--- a/src/app/playlist/playlist.component.ts
+++ b/src/app/playlist/playlist.component.ts
@@ -272,7 +272,7 @@ export class PlaylistComponent {
 
   openExportModal(): void {
     const modalRef = this.modalService.open(ExportPlaylistModalComponent, { size: 'lg' });
-    modalRef.componentInstance.tracks.set(this.playlist());
+    modalRef.componentInstance.tracks.set(this.playlist() ?? []);
     const exportTitle = this.isLikePage()
       ? this.translocoService.translate('mes_likes')
       : this.titre() || this.title();

--- a/src/app/routing/chunk-error-handler.spec.ts
+++ b/src/app/routing/chunk-error-handler.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { clearChunkRetryFlag, handleChunkLoadError, navigation } from './chunk-error-handler';
+
+describe('handleChunkLoadError', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+    vi.spyOn(navigation, 'reload').mockImplementation(() => {});
+  });
+
+  it('should ignore non-chunk errors', () => {
+    handleChunkLoadError(new Error('Some random error'));
+
+    expect(navigation.reload).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem('chunk-retry')).toBeNull();
+  });
+
+  it('should do nothing when sessionStorage is unavailable (SSR)', () => {
+    const original = globalThis.sessionStorage;
+    Object.defineProperty(globalThis, 'sessionStorage', { value: undefined, configurable: true });
+
+    try {
+      handleChunkLoadError(
+        new TypeError(
+          'Failed to fetch dynamically imported module: https://example.com/chunk-ABC.js'
+        )
+      );
+
+      expect(navigation.reload).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'sessionStorage', { value: original, configurable: true });
+    }
+  });
+
+  it('should reload on first Chrome chunk error', () => {
+    handleChunkLoadError(
+      new TypeError('Failed to fetch dynamically imported module: https://example.com/chunk-ABC.js')
+    );
+
+    expect(sessionStorage.getItem('chunk-retry')).toBe('1');
+    expect(navigation.reload).toHaveBeenCalledOnce();
+  });
+
+  it('should reload on first Firefox chunk error', () => {
+    handleChunkLoadError(
+      new TypeError('error loading dynamically imported module: https://example.com/chunk-ABC.js')
+    );
+
+    expect(sessionStorage.getItem('chunk-retry')).toBe('1');
+    expect(navigation.reload).toHaveBeenCalledOnce();
+  });
+
+  it('should reload on first Safari chunk error', () => {
+    handleChunkLoadError(new TypeError('Importing a module script failed.'));
+
+    expect(sessionStorage.getItem('chunk-retry')).toBe('1');
+    expect(navigation.reload).toHaveBeenCalledOnce();
+  });
+
+  it('should reload on first webpack chunk error', () => {
+    handleChunkLoadError(new Error('Loading chunk 123 failed'));
+
+    expect(sessionStorage.getItem('chunk-retry')).toBe('1');
+    expect(navigation.reload).toHaveBeenCalledOnce();
+  });
+
+  it('should not reload on second failure and clear flag', () => {
+    sessionStorage.setItem('chunk-retry', '1');
+
+    handleChunkLoadError(
+      new TypeError('Failed to fetch dynamically imported module: https://example.com/chunk-XYZ.js')
+    );
+
+    expect(sessionStorage.getItem('chunk-retry')).toBeNull();
+    expect(navigation.reload).not.toHaveBeenCalled();
+  });
+
+  it('should handle non-Error values gracefully', () => {
+    handleChunkLoadError('dynamically imported module');
+
+    expect(sessionStorage.getItem('chunk-retry')).toBe('1');
+    expect(navigation.reload).toHaveBeenCalledOnce();
+  });
+});
+
+describe('clearChunkRetryFlag', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('should remove the chunk-retry flag', () => {
+    sessionStorage.setItem('chunk-retry', '1');
+
+    clearChunkRetryFlag();
+
+    expect(sessionStorage.getItem('chunk-retry')).toBeNull();
+  });
+
+  it('should do nothing if no flag is set', () => {
+    clearChunkRetryFlag();
+
+    expect(sessionStorage.getItem('chunk-retry')).toBeNull();
+  });
+});

--- a/src/app/routing/chunk-error-handler.ts
+++ b/src/app/routing/chunk-error-handler.ts
@@ -1,0 +1,41 @@
+const CHUNK_ERROR_PATTERN =
+  /dynamically imported module|Loading chunk|Importing a module script failed/;
+
+const STORAGE_KEY = 'chunk-retry';
+
+/** @visibleForTesting */
+export const navigation = {
+  reload: (): void => location.reload(),
+};
+
+/** Clears the chunk-retry flag after a successful app bootstrap. */
+export function clearChunkRetryFlag(): void {
+  if (typeof sessionStorage !== 'undefined') {
+    try {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Ignore storage access failures in restricted environments
+    }
+  }
+}
+
+/**
+ * Handles stale chunk errors after deployments by reloading once.
+ * Uses a sessionStorage flag to prevent infinite reload loops.
+ */
+export function handleChunkLoadError(error: unknown): void {
+  if (typeof sessionStorage === 'undefined' || !CHUNK_ERROR_PATTERN.test(String(error))) {
+    return;
+  }
+
+  try {
+    if (sessionStorage.getItem(STORAGE_KEY)) {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } else {
+      sessionStorage.setItem(STORAGE_KEY, '1');
+      navigation.reload();
+    }
+  } catch {
+    // Storage blocked — skip reload to avoid infinite loop
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { AppComponent } from './app/app.component';
 import { InitService } from './app/services/init.service';
 import { PlayerService } from './app/services/player.service';
 import { sanitizeUrl } from './app/utils';
+import { clearChunkRetryFlag } from './app/routing/chunk-error-handler';
 import type * as SentryAngular from '@sentry/angular';
 
 let Sentry: typeof SentryAngular | undefined;
@@ -42,6 +43,7 @@ if (environment.SENTRY_DSN) {
       if (
         message.includes('Java object is gone') ||
         message.includes('Failed to fetch dynamically imported module') ||
+        message.includes('Importing a module script failed') ||
         message.includes('Access is denied for this document')
       ) {
         return null;
@@ -79,4 +81,6 @@ bootstrapApplication(AppComponent, {
     InitService,
     PlayerService,
   ],
-}).catch(err => console.error(err));
+})
+  .then(() => clearChunkRetryFlag())
+  .catch(err => console.error(err));


### PR DESCRIPTION
This pull request introduces robust chunk loading error recovery to handle stale chunk errors after deployments, improves error reporting logic to avoid sending non-actionable errors to Sentry, and adds minor defensive programming fixes. The main focus is on ensuring the app gracefully reloads when a user encounters a chunk loading error, while preventing infinite reload loops. Documentation is updated to reflect these changes.

**Chunk loading error recovery**
- Added `handleChunkLoadError` in `src/app/routing/chunk-error-handler.ts` and integrated it with Angular router via `withNavigationErrorHandler()` in `app.config.ts`. This detects chunk loading errors, reloads the page once using a sessionStorage flag, and prevents infinite reloads. Documentation in `.github/copilot-instructions.md` and `AGENTS.md` was updated to describe this behavior. [[1]](diffhunk://#diff-b5adc5b6de5d66650455f6cc210a48bb9daf32bc64b84c6da3a0b82d2de80235R1-R21) [[2]](diffhunk://#diff-fff0e6dc5626f82b3c71292d91384f36da38d5437a8ed1946eb9b903505ac035L8-R15) [[3]](diffhunk://#diff-fff0e6dc5626f82b3c71292d91384f36da38d5437a8ed1946eb9b903505ac035R30) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R19) [[5]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R368-R369)

**Error reporting improvements**
- Updated `errorInterceptor` to skip Sentry reporting for status `0` (network errors/aborted requests) and `401` (session expiry), and clarified comments. Added a test to ensure network errors are not reported. [[1]](diffhunk://#diff-c92e94716fb062ce1b31996d8f9bea98300ad9276accf094d7b425c579387c50L13-R14) [[2]](diffhunk://#diff-c92e94716fb062ce1b31996d8f9bea98300ad9276accf094d7b425c579387c50L30-R34) [[3]](diffhunk://#diff-c92e94716fb062ce1b31996d8f9bea98300ad9276accf094d7b425c579387c50L54-R58) [[4]](diffhunk://#diff-10006dc304e51c63503711b1f549655b38e7661afb91776f87ed5ebaf2a90954R143-R150)

**Defensive programming**
- Ensured that `tracks.set` in playlist export modals always receives an array, defaulting to `[]` if data is missing, to prevent runtime errors. [[1]](diffhunk://#diff-595d8e21b6e83b281ec35a5f61c9d058480d02c1ab0b9aa32cadf608f002e3faL181-R181) [[2]](diffhunk://#diff-3a04c1cfb282ceb1adfb4dd67f8d980e8c775e91e69f2b0cf614fda3ca9f92f9L275-R275)

**Sentry ignore list update**
- Added another chunk error pattern to the Sentry ignore list in `src/main.ts` to suppress known non-actionable errors.