### PR TITLE
lyrics responses

### DIFF
--- a/src/app/lyrics-panel/lyrics-panel.component.spec.ts
+++ b/src/app/lyrics-panel/lyrics-panel.component.spec.ts
@@ -128,13 +128,25 @@ describe('LyricsPanelComponent', () => {
     expect(component.activeLineIndex()).toBe(-1);
   });
 
-  it('should set error on lyrics_not_found', () => {
-    const errorResponse = new HttpErrorResponse({
-      error: { error: 'lyrics_not_found' },
-      status: 404,
-      statusText: 'Not Found',
-    });
-    lyricsServiceMock.getLyrics.mockReturnValue(throwError(() => errorResponse));
+  it('should set error on lyrics_not_found (success: false)', () => {
+    const notAvailableResponse: LyricsResponse = {
+      success: false,
+      error: 'lyrics_not_found',
+    };
+    lyricsServiceMock.getLyrics.mockReturnValue(of(notAvailableResponse));
+    queueStore.setQueue([mockVideo], '1');
+    fixture.detectChanges();
+
+    expect(component.error()).toBe('lyrics_none');
+    expect(component.isLoading()).toBe(false);
+  });
+
+  it('should set error on no_metadata (success: false)', () => {
+    const notAvailableResponse: LyricsResponse = {
+      success: false,
+      error: 'no_metadata',
+    };
+    lyricsServiceMock.getLyrics.mockReturnValue(of(notAvailableResponse));
     queueStore.setQueue([mockVideo], '1');
     fixture.detectChanges();
 
@@ -190,12 +202,11 @@ describe('LyricsPanelComponent', () => {
   });
 
   it('should reset state when no video is present', () => {
-    const errorResponse = new HttpErrorResponse({
-      error: { error: 'lyrics_not_found' },
-      status: 404,
-      statusText: 'Not Found',
-    });
-    lyricsServiceMock.getLyrics.mockReturnValue(throwError(() => errorResponse));
+    const notAvailableResponse: LyricsResponse = {
+      success: false,
+      error: 'lyrics_not_found',
+    };
+    lyricsServiceMock.getLyrics.mockReturnValue(of(notAvailableResponse));
     queueStore.setQueue([mockVideo], '1');
     fixture.detectChanges();
     expect(component.error()).toBe('lyrics_none');

--- a/src/app/lyrics-panel/lyrics-panel.component.ts
+++ b/src/app/lyrics-panel/lyrics-panel.component.ts
@@ -18,7 +18,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 import { Subject, switchMap, catchError, EMPTY } from 'rxjs';
 import { LyricsService } from '../services/lyrics.service';
-import { LyricsLine, LyricsErrorCode } from '../models/lyrics.model';
+import { LyricsLine } from '../models/lyrics.model';
 import { PlayerStore, QueueStore, UiStore } from '../store';
 
 /**
@@ -130,7 +130,7 @@ export class LyricsPanelComponent {
           return this.lyricsService.getLyrics(idVideo).pipe(
             catchError((err: HttpErrorResponse) => {
               this.isLoading.set(false);
-              this.error.set(this.mapErrorToTranslationKey(err));
+              this.error.set(this.mapErrorToTranslationKey(err.error?.error));
               return EMPTY;
             })
           );
@@ -139,6 +139,10 @@ export class LyricsPanelComponent {
       )
       .subscribe(response => {
         this.isLoading.set(false);
+        if (!response.success) {
+          this.error.set(this.mapErrorToTranslationKey(response.error));
+          return;
+        }
         this.isSynced.set(response.synced);
         this.lines.set(response.lines);
         this.plainLyrics.set(response.plainLyrics);
@@ -255,9 +259,7 @@ export class LyricsPanelComponent {
     this.isLoading.set(false);
   }
 
-  private mapErrorToTranslationKey(err: HttpErrorResponse): string {
-    const code = err.error?.error as LyricsErrorCode | undefined;
-
+  private mapErrorToTranslationKey(code: string | undefined): string {
     switch (code) {
       case 'lyrics_not_found':
       case 'no_metadata':

--- a/src/app/models/lyrics.model.ts
+++ b/src/app/models/lyrics.model.ts
@@ -11,9 +11,9 @@ export interface LyricsLine {
   text: string;
 }
 
-/** Successful lyrics response from GET /api/lyrics/:id_video */
-export interface LyricsResponse {
-  success: boolean;
+/** Successful lyrics response with data */
+export interface LyricsSuccessResponse {
+  success: true;
   /** Whether synchronized (timed) lyrics are available */
   synced: boolean;
   /** Pre-parsed synced lines. `null` when `synced` is `false` */
@@ -26,11 +26,11 @@ export interface LyricsResponse {
   artistName: string | null;
 }
 
-/** Error codes returned by the lyrics API */
-export type LyricsErrorCode =
-  | 'invalid_id_video'
-  | 'forbidden'
-  | 'not_found'
-  | 'no_metadata'
-  | 'lyrics_not_found'
-  | 'lrclib_unavailable';
+/** HTTP 200 response indicating lyrics are not available */
+export interface LyricsNotAvailableResponse {
+  success: false;
+  error: 'no_metadata' | 'lyrics_not_found';
+}
+
+/** API response from GET /api/lyrics/:id_video */
+export type LyricsResponse = LyricsSuccessResponse | LyricsNotAvailableResponse;

--- a/src/app/services/lyrics.service.spec.ts
+++ b/src/app/services/lyrics.service.spec.ts
@@ -45,8 +45,11 @@ describe('LyricsService', () => {
 
     service.getLyrics('12345').subscribe(data => {
       expect(data).toEqual(mockResponse);
-      expect(data.synced).toBe(true);
-      expect(data.lines).toHaveLength(2);
+      expect(data.success).toBe(true);
+      if (data.success) {
+        expect(data.synced).toBe(true);
+        expect(data.lines).toHaveLength(2);
+      }
     });
 
     const req = httpMock.expectOne(environment.URL_SERVER + 'lyrics/12345');
@@ -65,9 +68,12 @@ describe('LyricsService', () => {
     };
 
     service.getLyrics('67890').subscribe(data => {
-      expect(data.synced).toBe(false);
-      expect(data.lines).toBeNull();
-      expect(data.plainLyrics).toBeTruthy();
+      expect(data.success).toBe(true);
+      if (data.success) {
+        expect(data.synced).toBe(false);
+        expect(data.lines).toBeNull();
+        expect(data.plainLyrics).toBeTruthy();
+      }
     });
 
     const req = httpMock.expectOne(environment.URL_SERVER + 'lyrics/67890');
@@ -83,7 +89,31 @@ describe('LyricsService', () => {
     });
 
     const req = httpMock.expectOne(environment.URL_SERVER + 'lyrics/99999');
-    req.flush({ error: 'lyrics_not_found' }, { status: 404, statusText: 'Not Found' });
+    req.flush({ error: 'not_found' }, { status: 404, statusText: 'Not Found' });
+  });
+
+  it('should return and cache success:false responses (lyrics not available)', () => {
+    const notAvailableResponse: LyricsResponse = {
+      success: false,
+      error: 'lyrics_not_found',
+    };
+
+    service.getLyrics('no-lyrics').subscribe(data => {
+      expect(data.success).toBe(false);
+      if (!data.success) {
+        expect(data.error).toBe('lyrics_not_found');
+      }
+    });
+
+    const req = httpMock.expectOne(environment.URL_SERVER + 'lyrics/no-lyrics');
+    req.flush(notAvailableResponse);
+
+    // Second call — should use cache, no HTTP request
+    service.getLyrics('no-lyrics').subscribe(data => {
+      expect(data.success).toBe(false);
+    });
+
+    httpMock.expectNone(environment.URL_SERVER + 'lyrics/no-lyrics');
   });
 
   it('should encode the video ID in the URL', () => {
@@ -136,7 +166,7 @@ describe('LyricsService', () => {
     });
 
     const req1 = httpMock.expectOne(environment.URL_SERVER + 'lyrics/error-id');
-    req1.flush({ error: 'lyrics_not_found' }, { status: 404, statusText: 'Not Found' });
+    req1.flush({ error: 'not_found' }, { status: 404, statusText: 'Not Found' });
 
     // Second call — should hit HTTP again (not cached)
     service.getLyrics('error-id').subscribe();


### PR DESCRIPTION
This pull request refactors how lyrics API errors are handled and improves the type safety and clarity of lyrics response handling throughout the codebase. The main change is to standardize "no lyrics available" responses as HTTP 200 with `success: false`, instead of relying on HTTP error codes, and to update the code and tests accordingly.

**Lyrics API Response Refactor:**

- Updated `LyricsResponse` to be a discriminated union of `LyricsSuccessResponse` (for successful data) and `LyricsNotAvailableResponse` (`success: false` with specific error codes), removing the previous `LyricsErrorCode` type. [[1]](diffhunk://#diff-8f2955f891fd2fc016f95ec550656a8f82ddd600fae084d501d5b78c47f8c01fL14-R16) [[2]](diffhunk://#diff-8f2955f891fd2fc016f95ec550656a8f82ddd600fae084d501d5b78c47f8c01fL29-R36)

**Component Logic Updates:**

- Modified `LyricsPanelComponent` to handle `success: false` responses directly, setting the error state based on the new response shape rather than relying on HTTP errors. The error mapping method now takes a string error code instead of an `HttpErrorResponse`. [[1]](diffhunk://#diff-10690fcb613d0d7924e4717c7ac5afa42e8ef460d0e8c2615d2ee0b02b4fcd68L21-R21) [[2]](diffhunk://#diff-10690fcb613d0d7924e4717c7ac5afa42e8ef460d0e8c2615d2ee0b02b4fcd68L133-R133) [[3]](diffhunk://#diff-10690fcb613d0d7924e4717c7ac5afa42e8ef460d0e8c2615d2ee0b02b4fcd68R142-R145) [[4]](diffhunk://#diff-10690fcb613d0d7924e4717c7ac5afa42e8ef460d0e8c2615d2ee0b02b4fcd68L258-R262)

**Test Updates:**

- Updated tests in `lyrics-panel.component.spec.ts` to mock and assert the new `success: false` responses, ensuring the UI reacts appropriately to "lyrics not found" and "no metadata" cases. [[1]](diffhunk://#diff-4e4290b3c9285e931f1536df59f800092f8a83d5a96c1715c219749fbcb1da1aL131-R149) [[2]](diffhunk://#diff-4e4290b3c9285e931f1536df59f800092f8a83d5a96c1715c219749fbcb1da1aL193-R209)
- Improved `lyrics.service.spec.ts` tests to check for the new response shape, including caching behavior for `success: false` responses. [[1]](diffhunk://#diff-f482b2a4637602e5042723edeeaab152f8b9fc630aa0c91a796d444faa3627a0R48-R52) [[2]](diffhunk://#diff-f482b2a4637602e5042723edeeaab152f8b9fc630aa0c91a796d444faa3627a0R71-R76) [[3]](diffhunk://#diff-f482b2a4637602e5042723edeeaab152f8b9fc630aa0c91a796d444faa3627a0L86-R116) [[4]](diffhunk://#diff-f482b2a4637602e5042723edeeaab152f8b9fc630aa0c91a796d444faa3627a0L139-R169)