### PR TITLE
admin dashboard enhacements

### DIFF
--- a/src/app/admin/dashboard/dashboard.component.html
+++ b/src/app/admin/dashboard/dashboard.component.html
@@ -119,6 +119,85 @@
       </div>
     </section>
 
+    <!-- Preferences section -->
+    @if (langItems().length || darkModeItems().length) {
+      <section class="stats-section">
+        <h2 class="section-title">
+          <span class="material-icons" aria-hidden="true">tune</span>
+          {{ 'admin_dashboard_section_preferences' | transloco }}
+        </h2>
+        <div class="row g-3">
+          <!-- Language distribution -->
+          @if (langItems().length) {
+            <div class="col-md-6">
+              <div class="card distribution-card">
+                <div class="card-body">
+                  <h3 class="distribution-card__title">
+                    {{ 'admin_dashboard_preferences_language' | transloco }}
+                  </h3>
+                  @for (item of langItems(); track item.labelKey) {
+                    <div class="distribution-item">
+                      <div class="distribution-label">
+                        <span>{{ item.labelKey | transloco }}</span>
+                        <span class="distribution-label__count">
+                          {{ item.count | number: '' : 'fr' }}
+                          <span class="distribution-label__percent">({{ item.percent }}%)</span>
+                        </span>
+                      </div>
+                      <div
+                        class="progress"
+                        role="progressbar"
+                        [attr.aria-label]="(item.labelKey | transloco) + ' ' + item.percent + '%'"
+                        [attr.aria-valuenow]="item.percent"
+                        aria-valuemin="0"
+                        aria-valuemax="100"
+                      >
+                        <div class="progress-bar bg-primary" [style.width.%]="item.percent"></div>
+                      </div>
+                    </div>
+                  }
+                </div>
+              </div>
+            </div>
+          }
+
+          <!-- Dark mode distribution -->
+          @if (darkModeItems().length) {
+            <div class="col-md-6">
+              <div class="card distribution-card">
+                <div class="card-body">
+                  <h3 class="distribution-card__title">
+                    {{ 'admin_dashboard_preferences_dark_mode' | transloco }}
+                  </h3>
+                  @for (item of darkModeItems(); track item.labelKey) {
+                    <div class="distribution-item">
+                      <div class="distribution-label">
+                        <span>{{ item.labelKey | transloco }}</span>
+                        <span class="distribution-label__count">
+                          {{ item.count | number: '' : 'fr' }}
+                          <span class="distribution-label__percent">({{ item.percent }}%)</span>
+                        </span>
+                      </div>
+                      <div
+                        class="progress"
+                        role="progressbar"
+                        [attr.aria-label]="(item.labelKey | transloco) + ' ' + item.percent + '%'"
+                        [attr.aria-valuenow]="item.percent"
+                        aria-valuemin="0"
+                        aria-valuemax="100"
+                      >
+                        <div class="progress-bar bg-secondary" [style.width.%]="item.percent"></div>
+                      </div>
+                    </div>
+                  }
+                </div>
+              </div>
+            </div>
+          }
+        </div>
+      </section>
+    }
+
     <!-- Growth chart -->
     @if (growth()) {
       <section class="stats-section">

--- a/src/app/admin/dashboard/dashboard.component.scss
+++ b/src/app/admin/dashboard/dashboard.component.scss
@@ -115,6 +115,49 @@
   }
 }
 
+// Distribution cards (language & dark mode)
+.distribution-card {
+  border-radius: var(--radius-lg);
+  height: 100%;
+
+  .card-body {
+    padding: var(--spacing-md);
+  }
+}
+
+.distribution-card__title {
+  font-size: var(--text-base);
+  font-weight: 600;
+  margin-bottom: var(--spacing-md);
+}
+
+.distribution-item {
+  margin-bottom: var(--spacing-md);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.distribution-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: var(--text-sm);
+  margin-bottom: var(--spacing-xs);
+}
+
+.distribution-label__count {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.distribution-label__percent {
+  font-weight: 400;
+  color: var(--bs-secondary-color);
+  margin-left: var(--spacing-xs);
+}
+
 // Responsive
 @media (max-width: 575.98px) {
   .chart-wrapper {

--- a/src/app/admin/dashboard/dashboard.component.spec.ts
+++ b/src/app/admin/dashboard/dashboard.component.spec.ts
@@ -27,6 +27,8 @@ describe('DashboardComponent', () => {
       totalLikes: 15000,
       playlistsCreatedLast24h: 5,
       likesLast24h: 42,
+      usersByLanguage: { fr: 120, en: 45 },
+      usersByDarkMode: { enabled: 80, disabled: 90 },
     },
     growth: {
       signups: [
@@ -162,5 +164,41 @@ describe('DashboardComponent', () => {
     const chartData = component.signupChartData();
     expect(chartData.labels).toEqual([]);
     expect(chartData.datasets).toEqual([]);
+  });
+
+  it('should build langItems with correct percentages and order', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const items = component.langItems();
+    expect(items).toHaveLength(2);
+    // fr has 120 / 165 = 73%
+    expect(items[0].labelKey).toBe('admin_dashboard_lang_fr_FR');
+    expect(items[0].count).toBe(120);
+    expect(items[0].percent).toBe(73);
+    // en has 45 / 165 = 27%
+    expect(items[1].labelKey).toBe('admin_dashboard_lang_en_US');
+    expect(items[1].count).toBe(45);
+    expect(items[1].percent).toBe(27);
+  });
+
+  it('should build darkModeItems with correct label keys', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const items = component.darkModeItems();
+    expect(items).toHaveLength(2);
+    // disabled (90) > enabled (80)
+    expect(items[0].labelKey).toBe('admin_dashboard_dark_mode_off');
+    expect(items[0].count).toBe(90);
+    expect(items[0].percent).toBe(53);
+    expect(items[1].labelKey).toBe('admin_dashboard_dark_mode_on');
+    expect(items[1].count).toBe(80);
+    expect(items[1].percent).toBe(47);
+  });
+
+  it('should return empty distribution items when stats is null', () => {
+    expect(component.langItems()).toEqual([]);
+    expect(component.darkModeItems()).toEqual([]);
   });
 });

--- a/src/app/admin/dashboard/dashboard.component.ts
+++ b/src/app/admin/dashboard/dashboard.component.ts
@@ -45,6 +45,22 @@ interface StatCard {
   value: number;
 }
 
+interface DistributionItem {
+  labelKey: string;
+  count: number;
+  percent: number;
+}
+
+const LANG_LABEL_MAP: Record<string, string> = {
+  fr: 'admin_dashboard_lang_fr_FR',
+  en: 'admin_dashboard_lang_en_US',
+};
+
+const DARK_MODE_LABEL_MAP: Record<string, string> = {
+  enabled: 'admin_dashboard_dark_mode_on',
+  disabled: 'admin_dashboard_dark_mode_off',
+};
+
 @Component({
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
@@ -139,6 +155,32 @@ export class DashboardComponent implements OnInit {
         value: s.likesLast24h,
       },
     ];
+  });
+
+  readonly langItems = computed<DistributionItem[]>(() => {
+    const s = this.stats();
+    if (!s) return [];
+    const total = Object.values(s.usersByLanguage).reduce((sum, v) => sum + v, 0);
+    return Object.entries(s.usersByLanguage)
+      .map(([key, count]) => ({
+        labelKey: LANG_LABEL_MAP[key] ?? key,
+        count,
+        percent: total > 0 ? Math.round((count / total) * 100) : 0,
+      }))
+      .sort((a, b) => b.count - a.count);
+  });
+
+  readonly darkModeItems = computed<DistributionItem[]>(() => {
+    const s = this.stats();
+    if (!s) return [];
+    const total = Object.values(s.usersByDarkMode).reduce((sum, v) => sum + v, 0);
+    return Object.entries(s.usersByDarkMode)
+      .map(([key, count]) => ({
+        labelKey: DARK_MODE_LABEL_MAP[key] ?? key,
+        count,
+        percent: total > 0 ? Math.round((count / total) * 100) : 0,
+      }))
+      .sort((a, b) => b.count - a.count);
   });
 
   readonly signupChartData = computed<ChartConfiguration<'line'>['data']>(() => {

--- a/src/app/artist/artist.component.html
+++ b/src/app/artist/artist.component.html
@@ -75,10 +75,7 @@
                       <a routerLink="/admin/merge-artist" [queryParams]="{ source: idArtist() }">
                         <span class="material-icons" aria-hidden="true">merge_type</span>
                         {{ 'admin_merge_artists' | transloco }}
-                        <span
-                          class="material-icons admin-only-icon"
-                          aria-hidden="true"
-                          ngbTooltip="Admin"
+                        <span class="material-icons admin-only-icon" aria-hidden="true"
                           >admin_panel_settings</span
                         >
                       </a>

--- a/src/app/models/admin-dashboard.model.ts
+++ b/src/app/models/admin-dashboard.model.ts
@@ -21,6 +21,10 @@ export interface DashboardStats {
   totalLikes: number; // ← total_likes
   playlistsCreatedLast24h: number; // ← playlists_created_24h
   likesLast24h: number; // ← likes_24h
+
+  // Preferences
+  usersByLanguage: Record<string, number>; // ← users_by_language
+  usersByDarkMode: Record<string, number>; // ← users_by_dark_mode
 }
 
 export interface GrowthPoint {
@@ -51,6 +55,8 @@ export interface DashboardApiResponse {
     total_likes: number;
     playlists_created_24h: number;
     likes_24h: number;
+    users_by_language: Record<string, number>;
+    users_by_dark_mode: Record<string, number>;
   };
   growth: {
     signups: { date: string; count: number }[];

--- a/src/app/playlist/playlist.component.html
+++ b/src/app/playlist/playlist.component.html
@@ -174,10 +174,7 @@
                       <a routerLink="/admin/merge-album" [queryParams]="{ source: idPlaylist() }">
                         <span class="material-icons" aria-hidden="true">merge_type</span>
                         {{ 'admin_merge_albums' | transloco }}
-                        <span
-                          class="material-icons admin-only-icon"
-                          aria-hidden="true"
-                          ngbTooltip="Admin"
+                        <span class="material-icons admin-only-icon" aria-hidden="true"
                           >admin_panel_settings</span
                         >
                       </a>
@@ -335,10 +332,7 @@
                           <span class="material-icons">edit</span>
                           {{ 'rename_track' | transloco }}
                           @if (authStore.isAdmin() && !isOwner()) {
-                            <span
-                              class="material-icons admin-only-icon"
-                              aria-hidden="true"
-                              ngbTooltip="Admin"
+                            <span class="material-icons admin-only-icon" aria-hidden="true"
                               >admin_panel_settings</span
                             >
                           }

--- a/src/app/services/admin-dashboard.service.spec.ts
+++ b/src/app/services/admin-dashboard.service.spec.ts
@@ -23,6 +23,8 @@ describe('AdminDashboardService', () => {
       total_likes: 15000,
       playlists_created_24h: 5,
       likes_24h: 42,
+      users_by_language: { fr: 120, en: 45 },
+      users_by_dark_mode: { enabled: 80, disabled: 90 },
     },
     growth: {
       signups: [
@@ -66,6 +68,8 @@ describe('AdminDashboardService', () => {
       expect(data.stats.totalLikes).toBe(15000);
       expect(data.stats.playlistsCreatedLast24h).toBe(5);
       expect(data.stats.likesLast24h).toBe(42);
+      expect(data.stats.usersByLanguage).toEqual({ fr: 120, en: 45 });
+      expect(data.stats.usersByDarkMode).toEqual({ enabled: 80, disabled: 90 });
       expect(data.growth.signups).toHaveLength(2);
       expect(data.growth.signups[0]).toEqual({ date: '2026-03-01', count: 3 });
     });

--- a/src/app/services/admin-dashboard.service.ts
+++ b/src/app/services/admin-dashboard.service.ts
@@ -30,6 +30,8 @@ export class AdminDashboardService {
         totalLikes: raw.stats.total_likes,
         playlistsCreatedLast24h: raw.stats.playlists_created_24h,
         likesLast24h: raw.stats.likes_24h,
+        usersByLanguage: raw.stats.users_by_language,
+        usersByDarkMode: raw.stats.users_by_dark_mode,
       },
       growth: {
         signups: raw.growth.signups,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -560,5 +560,12 @@
   "admin_dashboard_total_likes": "Likes",
   "admin_dashboard_playlists_created_24h": "Playlists created (24h)",
   "admin_dashboard_likes_24h": "Likes (24h)",
-  "admin_dashboard_signups_chart": "Signups (last 30 days)"
+  "admin_dashboard_signups_chart": "Signups (last 30 days)",
+  "admin_dashboard_section_preferences": "User preferences",
+  "admin_dashboard_preferences_language": "Language",
+  "admin_dashboard_preferences_dark_mode": "Dark mode",
+  "admin_dashboard_lang_fr_FR": "French (fr_FR)",
+  "admin_dashboard_lang_en_US": "English (en_US)",
+  "admin_dashboard_dark_mode_on": "Enabled",
+  "admin_dashboard_dark_mode_off": "Disabled"
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -560,5 +560,12 @@
   "admin_dashboard_total_likes": "Likes",
   "admin_dashboard_playlists_created_24h": "Playlists créées (24h)",
   "admin_dashboard_likes_24h": "Likes (24h)",
-  "admin_dashboard_signups_chart": "Inscriptions (30 derniers jours)"
+  "admin_dashboard_signups_chart": "Inscriptions (30 derniers jours)",
+  "admin_dashboard_section_preferences": "Préférences utilisateurs",
+  "admin_dashboard_preferences_language": "Langue",
+  "admin_dashboard_preferences_dark_mode": "Mode sombre",
+  "admin_dashboard_lang_fr_FR": "Français (fr_FR)",
+  "admin_dashboard_lang_en_US": "Anglais (en_US)",
+  "admin_dashboard_dark_mode_on": "Activé",
+  "admin_dashboard_dark_mode_off": "Désactivé"
 }

--- a/src/styling/_utilities.scss
+++ b/src/styling/_utilities.scss
@@ -569,11 +569,16 @@
 // =============================================================================
 
 .admin-only-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-size: 1rem;
   vertical-align: middle;
   margin-left: var(--spacing-xs);
+  padding: 2px;
   color: rgb(var(--bs-primary-rgb));
-  opacity: 0.85;
+  background-color: var(--bs-dark);
+  border-radius: var(--radius-sm);
 }
 
 // =============================================================================
@@ -1102,6 +1107,11 @@ a.card,
   }
 
   &:hover .material-icons {
+    opacity: 1;
+  }
+
+  // Admin badge: always fully visible regardless of hover state
+  .admin-only-icon {
     opacity: 1;
   }
 


### PR DESCRIPTION
This pull request enhances the admin dashboard by introducing a new "User preferences" section, which visualizes the distribution of users by language and dark mode usage. It also adds the necessary backend integration, translations, styles, and comprehensive tests for these new features. Additionally, there are minor improvements to the admin icon styling and some markup clean-up in unrelated components.

**Dashboard User Preferences Visualization:**

* Added a new "User preferences" section to the admin dashboard, displaying language and dark mode distribution with progress bars and counts, using the new `langItems` and `darkModeItems` computed properties in `dashboard.component.html` and supporting SCSS styles. [[1]](diffhunk://#diff-1e4f89feb9c4b947f548f97bae621fbfbe5aa3ae7c84e4b0c1fe0eac7f9d931fR122-R198) [[2]](diffhunk://#diff-2fd214515fa17d5c946848fab27b4fdff0f69f5fe0e9633f16aae42cb124c1b0R118-R160)
* Defined new `DistributionItem` type, label maps, and computed properties in `dashboard.component.ts` to calculate and sort language and dark mode statistics for the dashboard. [[1]](diffhunk://#diff-57d7f4a315fde7f438d576bbd260699bd28b60c2a9385004ccce97ee7c816e56R48-R63) [[2]](diffhunk://#diff-57d7f4a315fde7f438d576bbd260699bd28b60c2a9385004ccce97ee7c816e56R160-R185)
* Extended the `DashboardStats` and `DashboardApiResponse` interfaces to include `usersByLanguage` and `usersByDarkMode` fields, and updated the dashboard service to map these fields from the backend API. [[1]](diffhunk://#diff-f633821e01ad5f812d90e4e5e26dd13063bc4f0e8e7878cb9f60124b37c27133R24-R27) [[2]](diffhunk://#diff-f633821e01ad5f812d90e4e5e26dd13063bc4f0e8e7878cb9f60124b37c27133R58-R59) [[3]](diffhunk://#diff-7f61a041e41324b0030bc1f988cdf095dfb54525256034796bcb2b94bfd73898R33-R34)

**Testing:**

* Added comprehensive tests for the new computed properties and backend mapping, ensuring correct calculation of percentages, label mapping, and handling of missing data in both the dashboard component and service. [[1]](diffhunk://#diff-c443b0af81c01809518734476db3706b8f90879e3b540164501827d7f2d23c8cR30-R31) [[2]](diffhunk://#diff-c443b0af81c01809518734476db3706b8f90879e3b540164501827d7f2d23c8cR168-R203) [[3]](diffhunk://#diff-8bb7c46842804b004ac9660b39b8bdaf6ac20f2fe7c1e7f2f45c20b6c4802d3aR26-R27) [[4]](diffhunk://#diff-8bb7c46842804b004ac9660b39b8bdaf6ac20f2fe7c1e7f2f45c20b6c4802d3aR71-R72)

**Localization:**

* Added English and French translations for the new dashboard section, language, and dark mode labels. [[1]](diffhunk://#diff-dbc555e31a2673b2c0f37c8a2e9f7853748ea7627d48047bb49358a39429412eL563-R570) [[2]](diffhunk://#diff-7164935394a83166925ce8964f8c1cf5c9979487b07f98dadf67e941403292fbL563-R570)

**Styling & Minor UI Improvements:**

* Improved `.admin-only-icon` styling for better visibility and alignment, and ensured the admin badge is always fully visible in cards. [[1]](diffhunk://#diff-353b45d302fa41d96bf302087bdae280b22492653b0a175aee7d215936debe42R572-R580) [[2]](diffhunk://#diff-353b45d302fa41d96bf302087bdae280b22492653b0a175aee7d215936debe42R1112-R1116)
* Cleaned up redundant tooltip markup for admin icons in unrelated components (`artist.component.html` and `playlist.component.html`). [[1]](diffhunk://#diff-1491e63a831a484c932f9b2d00ae62cc4c5ee5c041fdb2ad0513fd762badb77dL78-R78) [[2]](diffhunk://#diff-40f451f898f09695bed9ae84e9e8a29cb78ef17c9f3a1ea567a09fdb769f6c45L177-R177) [[3]](diffhunk://#diff-40f451f898f09695bed9ae84e9e8a29cb78ef17c9f3a1ea567a09fdb769f6c45L338-R335)