### PR TITLE
Handle scanner requests

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -42,8 +42,13 @@ if (environment.SENTRY_DSN) {
         (typeof event.message === 'string' ? event.message : '');
       if (
         message.includes('Java object is gone') ||
+        // Chunk load failures after deployments — non-actionable, covered by withNavigationErrorHandler
         message.includes('Failed to fetch dynamically imported module') ||
         message.includes('Importing a module script failed') ||
+        // Transient network loss — handled by errorInterceptor (status 0 shows connection-lost toast).
+        // Sentry serializes this as either the bare message or prefixed with the error type.
+        message === 'Failed to fetch' ||
+        message === 'TypeError: Failed to fetch' ||
         message.includes('Access is denied for this document')
       ) {
         return null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,16 @@ if (environment.SENTRY_DSN) {
     tracesSampleRate: 0.2,
     sendDefaultPii: false,
     beforeSend(event) {
+      // Drop SSR hostname rejection errors — caused by security scanners (Censys, Shodan)
+      // hitting the VPS hostname directly. The hostname guard middleware handles these at
+      // the Express level; this filter is a defensive fallback for any that slip through.
+      const isHostnameRejection = event.exception?.values?.some(
+        ex => ex.value?.includes('URL with hostname') && ex.value?.includes('is not allowed')
+      );
+      if (isHostnameRejection) {
+        return null;
+      }
+
       if (event.request?.url) {
         try {
           const url = new URL(event.request.url);
@@ -41,19 +51,34 @@ const indexHtml = join(serverDistFolder, 'index.server.html');
 
 const app = express();
 
+const ALLOWED_HOSTS = new Set([
+  'www.zeffyrmusic.com',
+  'zeffyrmusic.com',
+  'data.zeffyrmusic.com',
+  '146.59.155.20', // Server public IP (NAT — not visible via networkInterfaces())
+  '127.0.0.1',
+  'localhost',
+]);
+
 const commonEngine = new CommonEngine({
-  allowedHosts: [
-    'www.zeffyrmusic.com',
-    'zeffyrmusic.com',
-    'data.zeffyrmusic.com',
-    '146.59.155.20', // Server public IP (NAT — not visible via networkInterfaces())
-    '127.0.0.1',
-    'localhost',
-  ],
+  allowedHosts: [...ALLOWED_HOSTS],
 });
 
 app.disable('x-powered-by');
 app.set('etag', false);
+
+// Hostname guard — runs before all other middleware to silently drop requests from
+// security scanners (Censys, Shodan, Nmap) that hit the VPS hostname directly or send
+// no Host header (hostname becomes undefined). Destroying the socket avoids confirming
+// that a server is running, preventing technology fingerprinting by scanners.
+app.use((req, _res, next) => {
+  if (ALLOWED_HOSTS.has(req.hostname)) {
+    next();
+    return;
+  }
+  req.socket.destroy();
+});
+
 app.use(cookieParser());
 
 // Hashed static assets (JS, CSS, hashed fonts) — long-lived immutable cache.


### PR DESCRIPTION
This pull request enhances error handling and security for the application by improving Sentry error filtering and adding a hostname guard middleware. The main focus is on preventing unnecessary error reporting for known transient and scanner-related issues, and on silently dropping suspicious requests to protect against security scanners.

Error handling improvements:

* Added a filter in the Sentry configuration (both client and server) to drop errors related to transient network issues (e.g., "Failed to fetch") and to ignore "hostname not allowed" errors caused by security scanners probing the server with invalid hostnames. [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR45-R46) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R23-R32)

Security enhancements:

* Introduced an `ALLOWED_HOSTS` set and a hostname guard middleware in `src/server.ts` to silently destroy connections from requests with disallowed or missing hostnames. This prevents scanners from fingerprinting the server or confirming its presence, as no HTTP response is sent.