### PR TITLE
Fix seek button functionality

### DIFF
--- a/src/app/control-bar/control-bar.component.html
+++ b/src/app/control-bar/control-bar.component.html
@@ -71,10 +71,12 @@
         type="button"
         class="cb-btn-icon cb-btn-play"
         (click)="onPlayPause()"
-        [attr.aria-label]="playerStore.isPlaying() ? ('pause' | transloco) : ('lire' | transloco)"
+        [attr.aria-label]="
+          playerStore.showPauseIcon() ? ('pause' | transloco) : ('lire' | transloco)
+        "
       >
         <span class="material-icons" aria-hidden="true">{{
-          playerStore.isPlaying() ? 'pause' : 'play_arrow'
+          playerStore.showPauseIcon() ? 'pause' : 'play_arrow'
         }}</span>
       </button>
       <button

--- a/src/app/playlist/playlist.component.html
+++ b/src/app/playlist/playlist.component.html
@@ -84,7 +84,7 @@
             }
 
             <div class="playlist-actions">
-              @if (idPlaylist() !== currentIdPlaylistPlaying() || !playerStore.isPlaying()) {
+              @if (idPlaylist() !== currentIdPlaylistPlaying() || !playerStore.showPauseIcon()) {
                 <button
                   type="button"
                   class="btn btn-primary btn-action"

--- a/src/app/services/youtube-player.service.ts
+++ b/src/app/services/youtube-player.service.ts
@@ -96,6 +96,9 @@ export class YoutubePlayerService {
 
     switch (event.data) {
       case YT.PlayerState.UNSTARTED:
+        this.playerStore.setIdle();
+        this.stopProgressTracking();
+        break;
       case YT.PlayerState.ENDED:
       case YT.PlayerState.PAUSED:
         this.playerStore.pause();

--- a/src/app/store/player/player.models.ts
+++ b/src/app/store/player/player.models.ts
@@ -7,6 +7,7 @@ export type PlayerStatus = 'idle' | 'loading' | 'playing' | 'paused' | 'ended' |
 
 export interface PlayerState {
   status: PlayerStatus;
+  wasPlaying: boolean;
   currentTime: number;
   duration: number;
   loadedFraction: number;
@@ -20,6 +21,7 @@ export interface PlayerState {
 
 export const initialPlayerState: PlayerState = {
   status: 'idle',
+  wasPlaying: false,
   currentTime: 0,
   duration: 0,
   loadedFraction: 0,

--- a/src/app/store/player/player.store.spec.ts
+++ b/src/app/store/player/player.store.spec.ts
@@ -142,6 +142,55 @@ describe('PlayerStore', () => {
     });
   });
 
+  describe('showPauseIcon', () => {
+    it('should be false initially', () => {
+      expect(store.showPauseIcon()).toBe(false);
+    });
+
+    it('should be true when playing', () => {
+      store.play();
+      expect(store.showPauseIcon()).toBe(true);
+    });
+
+    it('should stay true during buffering after play (seek scenario)', () => {
+      store.play();
+      store.setLoading();
+      expect(store.showPauseIcon()).toBe(true);
+    });
+
+    it('should stay true during buffering after track change while playing', () => {
+      store.play();
+      store.setIdle(); // UNSTARTED from YouTube
+      store.setLoading(); // BUFFERING from YouTube
+      expect(store.showPauseIcon()).toBe(true);
+    });
+
+    it('should be false when paused', () => {
+      store.play();
+      store.pause();
+      expect(store.showPauseIcon()).toBe(false);
+    });
+
+    it('should stay false during buffering after track change while paused', () => {
+      store.play();
+      store.pause();
+      store.setIdle(); // UNSTARTED from YouTube
+      store.setLoading(); // BUFFERING from YouTube
+      expect(store.showPauseIcon()).toBe(false);
+    });
+
+    it('should stay false during initial load (never played)', () => {
+      store.setLoading();
+      expect(store.showPauseIcon()).toBe(false);
+    });
+
+    it('should be false after ended', () => {
+      store.play();
+      store.setEnded();
+      expect(store.showPauseIcon()).toBe(false);
+    });
+  });
+
   describe('Progress Controls', () => {
     it('should update progress with time only', () => {
       store.updateProgress(45);

--- a/src/app/store/player/player.store.ts
+++ b/src/app/store/player/player.store.ts
@@ -20,6 +20,9 @@ export const PlayerStore = signalStore(
     isPaused: computed(() => state.status() === 'paused'),
     isLoading: computed(() => state.status() === 'loading'),
     hasError: computed(() => state.status() === 'error'),
+    showPauseIcon: computed(
+      () => state.status() === 'playing' || (state.status() === 'loading' && state.wasPlaying())
+    ),
 
     progress: computed(() => {
       const duration = state.duration();
@@ -42,16 +45,16 @@ export const PlayerStore = signalStore(
     },
 
     play(): void {
-      patchState(store, { status: 'playing' });
+      patchState(store, { status: 'playing', wasPlaying: true });
     },
 
     pause(): void {
-      patchState(store, { status: 'paused' });
+      patchState(store, { status: 'paused', wasPlaying: false });
     },
 
     togglePlay(): boolean {
       const isPlaying = store.status() === 'playing';
-      patchState(store, { status: isPlaying ? 'paused' : 'playing' });
+      patchState(store, { status: isPlaying ? 'paused' : 'playing', wasPlaying: !isPlaying });
       return !isPlaying;
     },
 
@@ -60,7 +63,7 @@ export const PlayerStore = signalStore(
     },
 
     setEnded(): void {
-      patchState(store, { status: 'ended' });
+      patchState(store, { status: 'ended', wasPlaying: false });
     },
 
     setIdle(): void {


### PR DESCRIPTION
This pull request updates the logic for displaying the play/pause icon in the player controls to better handle buffering and state transitions, and introduces a new `wasPlaying` flag to track playback intent. The changes ensure that the pause icon remains visible during buffering if playback was already in progress, improving the user experience during track changes or seeking. The update also includes comprehensive tests for the new behavior.

**Player state management improvements:**

* Added a new `wasPlaying` boolean property to the `PlayerState` interface and initialized it in `initialPlayerState` to track if playback was recently active. [[1]](diffhunk://#diff-e2235c6faca08541bf2956a7ea416d2ec0fe53c20464fb1e25a41d84702d9b43R10) [[2]](diffhunk://#diff-e2235c6faca08541bf2956a7ea416d2ec0fe53c20464fb1e25a41d84702d9b43R24)
* Updated all player state transition methods (`play`, `pause`, `togglePlay`, `setEnded`) in `player.store.ts` to correctly update the new `wasPlaying` property alongside `status`. [[1]](diffhunk://#diff-54771b522ca83bb8475abfe56be4d5c15d03c44c2bb4b56319c5eb8628bd123bL45-R57) [[2]](diffhunk://#diff-54771b522ca83bb8475abfe56be4d5c15d03c44c2bb4b56319c5eb8628bd123bL63-R66)

**UI logic enhancements:**

* Introduced a new computed property `showPauseIcon` in `PlayerStore` that returns `true` if the player is playing, or is buffering after having played, ensuring the pause icon remains visible during expected buffering scenarios.
* Updated the play/pause button logic in `control-bar.component.html` and `playlist.component.html` to use `showPauseIcon()` instead of `isPlaying()`, aligning the UI with the improved state logic. [[1]](diffhunk://#diff-8a7cc72e220a66983ba2d071f750a9ce275ae440c38662dbd7928c4a1f0831f3L74-R79) [[2]](diffhunk://#diff-40f451f898f09695bed9ae84e9e8a29cb78ef17c9f3a1ea567a09fdb769f6c45L87-R87)

**Testing:**

* Added a comprehensive suite of tests for `showPauseIcon` in `player.store.spec.ts` to verify correct icon display across various player state transitions, including buffering, pausing, ending, and initial load.